### PR TITLE
Should link protobuf (prevent #3)

### DIFF
--- a/ext/cld3/extconf.rb
+++ b/ext/cld3/extconf.rb
@@ -17,8 +17,14 @@
 require "mkmf"
 
 # Check pkg-config first to inform the library is missing if so.
-unless pkg_config("protobuf") || have_library("protobuf")
-  abort "Can't find protobuf\n"
+def have_protobuf?
+  checking_for("protobuf by pkg-config") do
+    pkg_config("protobuf")
+  end
+end
+
+unless have_protobuf?
+  abort "Failed to locate protobuf"
 end
 
 FileUtils.mkdir_p("cld_3/protos")

--- a/ext/cld3/extconf.rb
+++ b/ext/cld3/extconf.rb
@@ -17,7 +17,9 @@
 require "mkmf"
 
 # Check pkg-config first to inform the library is missing if so.
-pkg_config("protobuf")
+unless pkg_config("protobuf") || have_library("protobuf")
+  abort "Can't find protobuf\n"
+end
 
 FileUtils.mkdir_p("cld_3/protos")
 FileUtils.mkdir_p("script_span")


### PR DESCRIPTION
When "-lprotobuf" can not be added to LIBS, installation is canceled.
This prevents installation of broken binary.