### PR TITLE
Abort install if failed to locate protobuf package. (prevent #3)

### DIFF
--- a/ext/cld3/extconf.rb
+++ b/ext/cld3/extconf.rb
@@ -17,7 +17,7 @@
 require "mkmf"
 
 # Check pkg-config first to inform the library is missing if so.
-pkg_config("protobuf")
+pkg_config("protobuf") or abort "Failed to locate protobuf"
 
 FileUtils.mkdir_p("cld_3/protos")
 FileUtils.mkdir_p("script_span")


### PR DESCRIPTION
Continue installing without collect LIBS will cause run-time error. Added abort.