### PR TITLE
Bump Version Number

### DIFF
--- a/cld3.gemspec
+++ b/cld3.gemspec
@@ -16,7 +16,7 @@
 
 Gem::Specification.new do |gem|
   gem.name = "cld3"
-  gem.version = "3.1.1"
+  gem.version = "3.1.2"
   gem.summary = "Compact Language Detector v3 (CLD3)"
   gem.description = "Compact Language Detector v3 (CLD3) is a neural network model for language identification."
   gem.license = "Apache-2.0"


### PR DESCRIPTION
Bump the version number so the latest fix (for #3) can be published for the RubyGem.