### PR TITLE
Support Ruby >= 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - protobuf-compiler
 language: ruby
 rvm:
+  - 2.6.0
   - 2.5.0
   - 2.4.3
   - 2.3.6

--- a/cld3.gemspec
+++ b/cld3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/akihikodaki/cld3-ruby"
   gem.author = "Akihiko Odaki"
   gem.email = "akihiko.odaki.4i@stu.hosei.ac.jp"
-  gem.required_ruby_version = [ ">= 2.3.0", "< 2.6.0" ]
+  gem.required_ruby_version = [ ">= 2.3.0", "< 2.7.0" ]
   gem.add_dependency "ffi", [ ">= 1.1.0", "< 1.10.0" ]
   gem.add_development_dependency "rspec", [ ">=3.0.0", "< 3.8.0" ]
   gem.files = Dir[


### PR DESCRIPTION
It's that time of the year again https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released

Also added development section to Readme