### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,15 @@ addons:
       - protobuf-compiler
 language: ruby
 rvm:
+  - ruby-head
+  - 2.7.0
   - 2.6.3
   - 2.5.5
   - 2.4.6
   - 2.3.8
   - rbx-3
+matrix:
+  allow_failures:
+  - rvm: ruby-head
 script:
   - rake spec

--- a/cld3.gemspec
+++ b/cld3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/akihikodaki/cld3-ruby"
   gem.author = "Akihiko Odaki"
   gem.email = "akihiko.odaki.4i@stu.hosei.ac.jp"
-  gem.required_ruby_version = [ ">= 2.3.0", "< 2.7.0" ]
+  gem.required_ruby_version = [ ">= 2.3.0", "< 3" ]
   gem.add_dependency "ffi", [ ">= 1.1.0", "< 1.11.0" ]
   gem.add_development_dependency "rspec", [ ">=3.0.0", "< 3.9.0" ]
   gem.files = Dir[


### PR DESCRIPTION
Fix #22 

- update gemspec
- Add ruby 2.7.0 and head to travis matrix

It'll cause a warning message like this but asap 2.7 support is more important I thought.

```
/home/unasuke/src/github.com/akihikodaki/cld3-ruby/intermediate/lib/cld3.rb:81: warning: rb_safe_level will be removed in Ruby 3.0
/home/unasuke/src/github.com/akihikodaki/cld3-ruby/intermediate/lib/cld3.rb:81: warning: rb_safe_level will be removed in Ruby 3.0
```