### PR TITLE
Load C extension from lib_path via ffi gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,6 +110,7 @@ task :default => :package
 desc "Run the tests"
 task "spec" => "intermediate/ext/cld3/Makefile" do
   sh "make -C intermediate/ext/cld3"
+  sh "install intermediate/ext/cld3/libcld3.#{RbConfig::CONFIG["DLEXT"]} intermediate/lib/libcld3.#{RbConfig::CONFIG["DLEXT"]}"
   sh "cd intermediate && bundle exec rspec"
 end
 

--- a/lib/cld3/unstable.rb
+++ b/lib/cld3/unstable.rb
@@ -18,15 +18,8 @@
 module CLD3
   module Unstable
     extend FFI::Library
-    
-    cld3_path = File.join(__dir__, "..", "libcld3." + RbConfig::CONFIG["DLEXT"])
 
-    unless File.exist?(cld3_path)
-      # for test and development
-      cld3_path = File.join(__dir__, "..", "..", "ext", "cld3", "libcld3." + RbConfig::CONFIG["DLEXT"])
-    end
-
-    ffi_lib cld3_path
+    ffi_lib File.join(__dir__, "..", "libcld3." + RbConfig::CONFIG["DLEXT"])
 
     module NNetLanguageIdentifier
       class Pointer < FFI::AutoPointer

--- a/lib/cld3/unstable.rb
+++ b/lib/cld3/unstable.rb
@@ -18,8 +18,15 @@
 module CLD3
   module Unstable
     extend FFI::Library
+    
+    cld3_path = File.join(__dir__, "..", "libcld3." + RbConfig::CONFIG["DLEXT"])
 
-    ffi_lib File.join(__dir__, "..", "..", "ext", "cld3", "libcld3." + RbConfig::CONFIG["DLEXT"])
+    unless File.exist?(cld3_path)
+      # for test and development
+      cld3_path = File.join(__dir__, "..", "..", "ext", "cld3", "libcld3." + RbConfig::CONFIG["DLEXT"])
+    end
+
+    ffi_lib cld3_path
 
     module NNetLanguageIdentifier
       class Pointer < FFI::AutoPointer


### PR DESCRIPTION
Hi, I found a wrong usage for RubyGems build directory. We should use `ext` directory only build usage, not production use. So, RubyGems 3.4 will remove the build artifact after the gem installation.

I added quick fix for this used by `lib/libcld3.so`. It's good to fix rake task for this.