### PR TITLE
fix issue for missing libcld3.bundle in ruby 3.2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ task :default => :package
 
 desc "Run the tests"
 task "spec" => "intermediate/ext/cld3/Makefile" do
-  sh "make -C intermediate/ext/cld3"
+  sh "make -C intermediate/ext/cld3 install sitearchdir=../../lib sitelibdir=../../lib"
   sh "cd intermediate && bundle exec rspec"
 end
 

--- a/lib/cld3/unstable.rb
+++ b/lib/cld3/unstable.rb
@@ -19,7 +19,7 @@ module CLD3
   module Unstable
     extend FFI::Library
 
-    ffi_lib File.join(__dir__, "..", "..", "ext", "cld3", "libcld3." + RbConfig::CONFIG["DLEXT"])
+    ffi_lib File.join(__dir__, "..", "libcld3." + RbConfig::CONFIG["DLEXT"])
 
     module NNetLanguageIdentifier
       class Pointer < FFI::AutoPointer


### PR DESCRIPTION
it seems that ruby 3.2.0 added some build directory cleaning after native extensions are built and this removes ext/cld3/libcld3.bundler leading to this error:

Could not open library libcld3.bundle'

According to https://github.com/rubygems/rubygems/issues/6205 the "fix" is to reference the file inside the lib directory

